### PR TITLE
fix: hard-code column start position offset in JsonResult utility

### DIFF
--- a/lib/result/JsonResult.ts
+++ b/lib/result/JsonResult.ts
@@ -46,10 +46,11 @@ export default class JsonResult implements IOperationResult {
     }
 
     private getRows(columns: Array<Column>, descriptors: Array<ColumnDesc>): Array<any> {
+        const columnStartPosition = Math.min(...descriptors.map(d => d.position));
         return descriptors.reduce((rows, descriptor) => {
             return this.getSchemaValues(
                 descriptor,
-                columns[descriptor.position - 1]
+                columns[descriptor.position - columnStartPosition]
             ).reduce((result, value, i) => {
                 if (!result[i]) {
                     result[i] = {};


### PR DESCRIPTION
Some Hive-compatible engines (Spark Thrift Server, Kyuubi, for example) have zero-based column start
position rather than one. Hard coding column position offset value with -1 will cause uncaught
exception errors (not to mention it's a magic number).