### PR TITLE
chore: fix thrift vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "node-int64": "^0.4.0",
-    "thrift": "^0.20.0"
+    "thrift": "^0.23.0"
   },
   "czConfig": {
     "path": "node_modules/cz-conventional-changelog"


### PR DESCRIPTION
Security vulnerability in thrift < 0.23.0 causes audits to fail in dependent projects.

This PR updates thrift to a version with a fix for [GHSA-r67j-r569-jrwp](https://github.com/advisories/GHSA-r67j-r569-jrwp)

No lock file changes, due to `package-lock=false` in `.npmrc`

There seem to be no breaking changes in thrift@0.21.0 through 0.23.0. Locally all tests passed.